### PR TITLE
Updated obsolete pev info in 'DISCOVER THE TOOLS'

### DIFF
--- a/discover-the-tools/examine+static+properties/pe+files.md
+++ b/discover-the-tools/examine+static+properties/pe+files.md
@@ -86,9 +86,9 @@ Analyze static properties of PE files.
 
 Analyze PE files and extract strings from them
 
-**Website**: [http://pev.sourceforge.net](http://pev.sourceforge.net)\
+**Website**: [https://pev.sourceforge.io](https://pev.sourceforge.io)\
 **Author**: Fernando Merces, Jardel Weyrich\
-**License**: GNU General Public License (GPL) v2: [https://github.com/merces/pev/blob/master/LICENSE](https://github.com/merces/pev/blob/master/LICENSE)\
+**License**: GNU General Public License (GPL) v2: [https://github.com/mentebinaria/readpe/blob/master/LICENSE](https://github.com/mentebinaria/readpe/blob/master/LICENSE)\
 **Notes**: pestr, readpe, pedis, pehash, pescan, peldd, peres\
 **State File**: [remnux.packages.pev](https://github.com/REMnux/salt-states/blob/master/remnux/packages/pev.sls)
 


### PR DESCRIPTION
`http://pev.sourceforge.net` redirects to `https://pev.sourceforge.io` and the `pev` project has been moved to https://github.com/mentebinaria/readpe.